### PR TITLE
Programmatically set up Google Cloud pubsub and Scheduler job

### DIFF
--- a/BoxingSchedulerServer/functions/silently-notify-ios-app/README.md
+++ b/BoxingSchedulerServer/functions/silently-notify-ios-app/README.md
@@ -26,13 +26,22 @@ python main.py
 
 ## Deploy
 
+### Upsert schedule changes
+
 ```zsh
 ./deploy-setup
+```
+
+### Upsert function source code changes
+
+```zsh
 ./deploy-function
 ```
 
-To force the remote function to run, to verify the deployment before its next
-scheduled run:
+### Testing
+
+To verify the deployment before its next scheduled run, you may want to force
+the remote function to run. You should see an `OK` response.
 
 ```zsh
 (export name="${PWD##*/}"; gcloud functions call "$name" --data='{}')

--- a/BoxingSchedulerServer/functions/silently-notify-ios-app/README.md
+++ b/BoxingSchedulerServer/functions/silently-notify-ios-app/README.md
@@ -2,27 +2,15 @@
 
 ## Prerequisites
 
-### Google Cloud Scheduler
-
-This project requires the `gcloud` command, pointed at a Google Cloud project
-with a Google Cloud Pub/Sub topic `cron-topic` and a Google Cloud Scheduler job
-targeting that topic (running every e.g. 10 minutes). Follow the steps from the
-following Google tutorials.
-
-- https://cloud.google.com/scheduler/docs/schedule-run-cron-job
-- https://cloud.google.com/scheduler/docs/tut-pub-sub
-
-### Environment Variables
-
-Export the following environment variables (perhaps via
-[direnv](https://direnv.net/)).
-
-- `FIREBASE_CLOUD_MANAGER_SERVER_KEY` from
-  [the Firebase console](https://console.firebase.google.com/) > Project
-  settings > Cloud Messaging tab > Cloud Messaging API (Legacy)
-- `FIREBASE_CLOUD_MANAGER_TOKEN` printed in the iOS app by implementing a
-  delegate method. See
-  [this tutorial](https://swiftsenpai.com/testing/send-silent-push-notifications/).
+- `gcloud`
+- Export the following environment variables (perhaps via
+  [direnv](https://direnv.net/)).
+  - `FIREBASE_CLOUD_MANAGER_SERVER_KEY`, from
+    [the Firebase console](https://console.firebase.google.com/) > Project
+    settings > Cloud Messaging tab > Cloud Messaging API (Legacy).
+  - `FIREBASE_CLOUD_MANAGER_TOKEN`, printed in the iOS app, by implementing a
+    delegate method. See
+    [this tutorial](https://swiftsenpai.com/testing/send-silent-push-notifications/).
 
 ## Install
 
@@ -39,7 +27,7 @@ python main.py
 ## Deploy
 
 ```zsh
-./deploy-secrets
+./deploy-setup
 ./deploy-function
 ```
 
@@ -47,5 +35,10 @@ To force the remote function to run, to verify the deployment before its next
 scheduled run:
 
 ```zsh
-gcloud functions call "${PWD##*/}" --data='{}'
+(export name="${PWD##*/}"; gcloud functions call "$name" --data='{}')
 ```
+
+## Further Reading
+
+- https://cloud.google.com/scheduler/docs/schedule-run-cron-job
+- https://cloud.google.com/scheduler/docs/tut-pub-sub

--- a/BoxingSchedulerServer/functions/silently-notify-ios-app/deploy-secrets
+++ b/BoxingSchedulerServer/functions/silently-notify-ios-app/deploy-secrets
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-echo -n "$FIREBASE_CLOUD_MANAGER_SERVER_KEY" | gcloud secrets versions add FIREBASE_CLOUD_MANAGER_SERVER_KEY --data-file=-
-echo -n "$FIREBASE_CLOUD_MANAGER_TOKEN" | gcloud secrets versions add FIREBASE_CLOUD_MANAGER_TOKEN --data-file=-

--- a/BoxingSchedulerServer/functions/silently-notify-ios-app/deploy-setup
+++ b/BoxingSchedulerServer/functions/silently-notify-ios-app/deploy-setup
@@ -8,19 +8,20 @@ topic_name='cron-topic'
 # Create topic
 
 set +e
-error=$(
+stdout=$(
   gcloud pubsub topics create $topic_name 2>&1
 )
+exit_code=$?
 set -e
-if [[ -n $error && ! ${error} =~ 'already exists' ]]; then
-  echo >&2 "$error"
+if [[ $exit_code -ne 0 && ! ${stdout} =~ 'already exists' ]]; then
+  echo >&2 "$stdout"
   exit 1
 fi
 
 # Create Google Cloud Scheduler job
 
 set +e
-error=$(
+stdout=$(
   gcloud scheduler jobs create pubsub "$job_name" \
     --location=us-west1 \
     --message-body 'Message body to appease Google Cloud' \
@@ -28,8 +29,9 @@ error=$(
     --time-zone='America/Los_Angeles' \
     --topic "$topic_name" 2>&1
 )
+exit_code=$?
 set -e
-if [[ ${error} =~ 'already exists' ]]; then
+if [[ $exit_code -ne 0 && ${stdout} =~ 'already exists' ]]; then
   # TODO: DRY above create with update/upsert
   gcloud scheduler jobs update pubsub "$job_name" \
     --location=us-west1 \
@@ -37,8 +39,8 @@ if [[ ${error} =~ 'already exists' ]]; then
     --schedule '0 * * * *' \
     --time-zone='America/Los_Angeles' \
     --topic "$topic_name"
-elif [[ -n $error ]]; then
-  echo >&2 "$error"
+elif [[ $exit_code -ne 0 ]]; then
+  echo >&2 "$stdout"
   exit 1
 fi
 

--- a/BoxingSchedulerServer/functions/silently-notify-ios-app/deploy-setup
+++ b/BoxingSchedulerServer/functions/silently-notify-ios-app/deploy-setup
@@ -5,7 +5,7 @@ set -e
 job_name="${PWD##*/}"
 topic_name='cron-topic'
 
-# Create topic
+# Upsert topic
 
 set +e
 stdout=$(
@@ -18,7 +18,7 @@ if [[ $exit_code -ne 0 && ! ${stdout} =~ 'already exists' ]]; then
   exit 1
 fi
 
-# Create Google Cloud Scheduler job
+# Upsert Google Cloud Scheduler job
 
 set +e
 stdout=$(
@@ -44,7 +44,7 @@ elif [[ $exit_code -ne 0 ]]; then
   exit 1
 fi
 
-# Create secrets
+# Upsert secrets
 
 echo -n "$FIREBASE_CLOUD_MANAGER_SERVER_KEY" | gcloud secrets versions add FIREBASE_CLOUD_MANAGER_SERVER_KEY --data-file=-
 echo -n "$FIREBASE_CLOUD_MANAGER_TOKEN" | gcloud secrets versions add FIREBASE_CLOUD_MANAGER_TOKEN --data-file=-

--- a/BoxingSchedulerServer/functions/silently-notify-ios-app/deploy-setup
+++ b/BoxingSchedulerServer/functions/silently-notify-ios-app/deploy-setup
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+job_name="${PWD##*/}"
+topic_name='cron-topic'
+
+# Create topic
+
+set +e
+error=$(
+  gcloud pubsub topics create $topic_name 2>&1
+)
+set -e
+if [[ -n $error && ! ${error} =~ 'already exists' ]]; then
+  echo >&2 "$error"
+  exit 1
+fi
+
+# Create Google Cloud Scheduler job
+
+set +e
+error=$(
+  gcloud scheduler jobs create pubsub "$job_name" \
+    --location=us-west1 \
+    --message-body 'Message body to appease Google Cloud' \
+    --schedule '0 * * * *' \
+    --time-zone='America/Los_Angeles' \
+    --topic "$topic_name" 2>&1
+)
+set -e
+if [[ ${error} =~ 'already exists' ]]; then
+  # TODO: DRY above create with update/upsert
+  gcloud scheduler jobs update pubsub "$job_name" \
+    --location=us-west1 \
+    --message-body 'Message body to appease Google Cloud' \
+    --schedule '0 * * * *' \
+    --time-zone='America/Los_Angeles' \
+    --topic "$topic_name"
+elif [[ -n $error ]]; then
+  echo >&2 "$error"
+  exit 1
+fi
+
+# Create secrets
+
+echo -n "$FIREBASE_CLOUD_MANAGER_SERVER_KEY" | gcloud secrets versions add FIREBASE_CLOUD_MANAGER_SERVER_KEY --data-file=-
+echo -n "$FIREBASE_CLOUD_MANAGER_TOKEN" | gcloud secrets versions add FIREBASE_CLOUD_MANAGER_TOKEN --data-file=-


### PR DESCRIPTION
Hot off the heels of #1, let's reduce its prerequisite manual setup.

# Description

Programmatically set up prerequisite Google Cloud components in a Bash script, rather than requiring the reader to (guess how to) set up manually in Google Cloud's GUI, out of band.

* Reduce manual steps in README

This PR's imperative setup script is in lieu of a declarative description of our Google Cloud code. That could be codified in e.g. Terraform. I've explored Terraform, but I found it heavyweight for 1 cloud function. So, a 1-off, admittedly verbose Bash script it is!

# Open Issues

- [x] 🐛 Update branches work, yet create paths exit the script with code `1`