### PR TITLE
Fix app badge count

### DIFF
--- a/BoxingScheduler/AppDelegate.swift
+++ b/BoxingScheduler/AppDelegate.swift
@@ -26,10 +26,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
           let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
           UNUserNotificationCenter.current().requestAuthorization(options: authOptions, completionHandler: { _, _ in })
             
+            /* Ideally the badge count would be taken from the push notification's apns value (set server side),
+            but since I don't have a backend this will have to do */
             getAvailableClassCount() { availableClassCount in
-                print("Available Class Count: \(availableClassCount)")
                 DispatchQueue.main.async {
-                    UIApplication.shared.applicationIconBadgeNumber = availableClassCount ?? -1
+                    UIApplication.shared.applicationIconBadgeNumber = availableClassCount
                 }
             }
             
@@ -132,7 +133,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         watchedClasses.getAllClasses() { allClassList in
             let nowAvailableClassCount = watchedClasses.getNowAvailableClasses(from: allClassList).count
             
+            if nowAvailableClassCount >= 1 {
             completion(nowAvailableClassCount)
+            } else {
+                // Passing in -1 removes the app badge
+                completion(-1)
+            }
         }
     }
 }

--- a/BoxingScheduler/AppDelegate.swift
+++ b/BoxingScheduler/AppDelegate.swift
@@ -13,7 +13,6 @@ import FirebaseMessaging
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         BGTaskScheduler.shared.register(forTaskWithIdentifier: "com.emilykcorso.fetchScheduleData", using: nil) { (task) in
             self.handleAppRefreshTask(task: task as! BGAppRefreshTask)
@@ -26,6 +25,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
           let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
           UNUserNotificationCenter.current().requestAuthorization(options: authOptions, completionHandler: { _, _ in })
+            
+            getAvailableClassCount() { availableClassCount in
+                print("Available Class Count: \(availableClassCount)")
+                DispatchQueue.main.async {
+                    UIApplication.shared.applicationIconBadgeNumber = availableClassCount ?? -1
+                }
+            }
+            
         } else {
           let settings: UIUserNotificationSettings =
             UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
@@ -119,6 +126,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             print("Unable to submit task: \(error.localizedDescription)")
         }
     }
+    
+    func getAvailableClassCount(_ completion: @escaping (Int) -> Void) {
+        let watchedClasses = WatchedClasses()
+        watchedClasses.getAllClasses() { allClassList in
+            let nowAvailableClassCount = watchedClasses.getNowAvailableClasses(from: allClassList).count
+            
+            completion(nowAvailableClassCount)
+        }
+    }
 }
 
 extension AppDelegate: MessagingDelegate {
@@ -127,4 +143,3 @@ extension AppDelegate: MessagingDelegate {
         NotificationCenter.default.post(name: Notification.Name("FCMToken"), object: nil, userInfo: tokenDict)
     }
 }
-


### PR DESCRIPTION
This changes the app's badge count from the default which was a reflection of how many push notifications were received (which were also never cleared and thus pretty high) -- this was a vacuous indicator. Now the badge count reflects the number of watched classes that are available.

**This may NOT update until the user opens the app. I'm still testing whether it can update this in the background when receiving pushes, but it might. 