### PR TITLE
Fix class selection

### DIFF
--- a/BoxingScheduler/View Controllers/ScheduleViewController.swift
+++ b/BoxingScheduler/View Controllers/ScheduleViewController.swift
@@ -159,7 +159,7 @@ class ScheduleViewController: UITableViewController {
     
     @objc func startEditing() {
         tableView.isEditing.toggle()
-        self.editButtonItem.title = "Done"
+        self.editButtonItem.title = tableView.isEditing ? "Done" : "Select"
         print("Editing enabled")
     }
     

--- a/BoxingScheduler/View Controllers/ScheduleViewController.swift
+++ b/BoxingScheduler/View Controllers/ScheduleViewController.swift
@@ -77,7 +77,8 @@ class ScheduleViewController: UITableViewController {
         }
 
         let mbaClass = dateList[indexPath.section].classes[indexPath.row]
-        cell.setCellText(mbaClass: mbaClass)
+        let classIsSelected = selectedClasses.contains(mbaClass)
+        cell.configureForClass(mbaClass, classIsSelected)
         
         return cell
     }
@@ -97,6 +98,17 @@ class ScheduleViewController: UITableViewController {
                 self.editButtonItem.action = #selector(submitSelections)
             }
         }
+        
+        
+        
+//        if let selections = DataStorage().retrieve() {
+//            if selections != self.selectedClasses {
+//                self.editButtonItem.title = "Submit"
+//                self.editButtonItem.action = #selector(submitSelections)
+//            }
+//        }
+        
+        
     }
     
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
@@ -134,13 +146,13 @@ class ScheduleViewController: UITableViewController {
     
     func configureNavBarButtons() {
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "slider.horizontal.3"), style: .plain, target: self, action: #selector(showSettings))
-        self.navigationItem.rightBarButtonItem = editButtonItem
-        if tableView.isEditing == true {
-            editButtonItem.action = #selector(submitSelections)
-        } else {
-            editButtonItem.action = #selector(startEditing)
-            editButtonItem.title = "Select"
-        }
+//        self.navigationItem.rightBarButtonItem = editButtonItem
+//        if tableView.isEditing == true {
+//            editButtonItem.action = #selector(submitSelections)
+//        } else {
+//            editButtonItem.action = #selector(startEditing)
+//            editButtonItem.title = "Select"
+//        }
     }
     
     @objc func showSettings() {

--- a/BoxingScheduler/View Controllers/ScheduleViewController.swift
+++ b/BoxingScheduler/View Controllers/ScheduleViewController.swift
@@ -91,7 +91,7 @@ class ScheduleViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         let mbaClass = dateList[indexPath.section].classes[indexPath.row]
-        if mbaClass.spotsAvailable == 0 && !selectedClasses.contains(where: { $0 == mbaClass }) {
+        if mbaClass.spotsAvailable == 0 { //&& !selectedClasses.contains(where: { $0 == mbaClass }) {
             return true
         } else {
             return false
@@ -100,7 +100,7 @@ class ScheduleViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         let mbaClass = dateList[indexPath.section].classes[indexPath.row]
-        if mbaClass.spotsAvailable == 0 && !selectedClasses.contains(where: { $0 == mbaClass }) {
+        if mbaClass.spotsAvailable == 0 {
             return indexPath
         } else {
             // disable selection for rows that shouldn't be selectable

--- a/BoxingScheduler/View Controllers/ScheduleViewController.swift
+++ b/BoxingScheduler/View Controllers/ScheduleViewController.swift
@@ -46,6 +46,16 @@ class ScheduleViewController: UITableViewController {
             print("No saved classes retreived")
         }
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        do {
+            try DataStorage().save(selectedClasses)
+        } catch {
+            print("Saving classList failed in ScheduleViewController")
+        }
+    }
 
     // MARK: - Table view data source
 

--- a/BoxingScheduler/View Controllers/ScheduleViewController.swift
+++ b/BoxingScheduler/View Controllers/ScheduleViewController.swift
@@ -14,7 +14,10 @@ class ScheduleViewController: UITableViewController {
             dateList = dateList.sorted()
             // TODO: Remove line below when done testing.
             // This line inserts a random item at the top of the list so it's easy to tell if the list is updating.
-            dateList.insert(dateList.randomElement()!, at: 0)
+//            let randomDate = dateList.randomElement()!
+//            let mbaClass = randomDate.classes[0]
+//            mbaClass.spotsAvailable = 0
+//            dateList.insert(randomDate, at: 0)
         }
     }
     var selectedClasses = [MbaClass]()
@@ -23,7 +26,6 @@ class ScheduleViewController: UITableViewController {
         super.viewDidLoad()
         self.navigationItem.title = "Schedule"
         tableView.register(MbaClassTableViewCell.self, forCellReuseIdentifier: MbaClassTableViewCell.identifier)
-//        tableView.allowsMultipleSelectionDuringEditing = true
         tableView.allowsMultipleSelection = true
         
         populateDateList()
@@ -109,27 +111,7 @@ class ScheduleViewController: UITableViewController {
             }
         }
         self.tableView.reloadData()
-        
-        
-        
-//        if let selections = DataStorage().retrieve() {
-//            if selections != self.selectedClasses {
-//                self.editButtonItem.title = "Submit"
-//                self.editButtonItem.action = #selector(submitSelections)
-//            }
-//        }
-        
-        
     }
-    
-//    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-//        let mbaClass = dateList[indexPath.section].classes[indexPath.row]
-//        if mbaClass.spotsAvailable == 0 { //&& !selectedClasses.contains(where: { $0 == mbaClass }) {
-//            return true
-//        } else {
-//            return false
-//        }
-//    }
     
     override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         let mbaClass = dateList[indexPath.section].classes[indexPath.row]
@@ -159,13 +141,6 @@ class ScheduleViewController: UITableViewController {
     
     func configureNavBarButtons() {
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "slider.horizontal.3"), style: .plain, target: self, action: #selector(showSettings))
-//        self.navigationItem.rightBarButtonItem = editButtonItem
-//        if tableView.isEditing == true {
-//            editButtonItem.action = #selector(submitSelections)
-//        } else {
-//            editButtonItem.action = #selector(startEditing)
-//            editButtonItem.title = "Select"
-//        }
     }
     
     @objc func showSettings() {
@@ -190,34 +165,6 @@ class ScheduleViewController: UITableViewController {
         DispatchQueue.main.async {
             self.tableView.reloadData()
         }
-    }
-    
-    @objc func startEditing() {
-        tableView.isEditing.toggle()
-        self.editButtonItem.title = tableView.isEditing ? "Done" : "Select"
-        print("Editing enabled")
-    }
-    
-    @objc func submitSelections() {
-        tableView.isEditing.toggle()
-        self.editButtonItem.action = #selector(startEditing)
-        self.editButtonItem.title = "Select"
-        
-        do {
-            try DataStorage().save(selectedClasses)
-        } catch {
-            print("Saving classList failed in ScheduleViewController")
-        }
-        
-        let ac = UIAlertController(title: "Class Selections Submitted", message: "You can view/ edit your selections in the Watched Classes tab", preferredStyle: .alert)
-        let seeWatchedClasses = UIAlertAction(title: "See Watched Classes", style: .default) { _ in
-            // Navigate to the watchedClasses tab
-            self.tabBarController?.selectedIndex = 1
-        }
-        let done = UIAlertAction(title: "Done", style: .default)
-        ac.addAction(seeWatchedClasses)
-        ac.addAction(done)
-        navigationController?.present(ac, animated: true)
     }
     
     func registerForNotifications() {

--- a/BoxingScheduler/Views/MbaClassTableViewCell.swift
+++ b/BoxingScheduler/Views/MbaClassTableViewCell.swift
@@ -18,8 +18,19 @@ class MbaClassTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func setCellText(mbaClass: MbaClass) {
+    func configureForClass(_ mbaClass: MbaClass, _ classIsSelected: Bool) {
         textLabel?.text = "\(mbaClass.name)"
         detailTextLabel?.text = "Spots available: \(mbaClass.spotsAvailable)"
+        
+        if mbaClass.spotsAvailable != 0 {
+            backgroundColor = .lightGray
+        } else {
+            if classIsSelected {
+                backgroundColor = .purple
+            } else {
+                backgroundColor = .white
+            }
+        }
+        
     }
 }


### PR DESCRIPTION
Changes included in this PR:

- Remove the upper right selection button from Schedule page such that there is no editing mode anymore. Now the user just selects the classes that they want directly.
- Refactor selection to persist selections immediately on tap instead of after tapping "Submit"
- Show already selected classes
- Make it possible to de-select classes that were already selected (even after navigating away from the schedule page and back)
- Redesign cells such that background color indicates whether a class can be selected (white), cannot be selected (gray), or is currently selected (purple)
- Comment out the test class inserted in the dateList didSet so that it doesn't cause the class duplication bug (this is just for testing anyway)