### PR TITLE
Fix watched classes not updating on first access

### DIFF
--- a/BoxingScheduler/View Controllers/ScheduleViewController.swift
+++ b/BoxingScheduler/View Controllers/ScheduleViewController.swift
@@ -51,12 +51,6 @@ class ScheduleViewController: UITableViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        
-        do {
-            try DataStorage().save(selectedClasses)
-        } catch {
-            print("Saving classList failed in ScheduleViewController")
-        }
     }
 
     // MARK: - Table view data source
@@ -110,6 +104,8 @@ class ScheduleViewController: UITableViewController {
                 selectedClasses.remove(at: selectedClasses.firstIndex(of: mbaClass)!)
             }
         }
+        
+        saveSelections()
         self.tableView.reloadData()
     }
     
@@ -172,6 +168,14 @@ class ScheduleViewController: UITableViewController {
             if let userInfo = notification.userInfo, let schedule = userInfo["schedule"] as? [ClassDate] {
                 self.populateDateListFromNotification(schedule)
             }
+        }
+    }
+    
+    func saveSelections() {
+        do {
+            try DataStorage().save(selectedClasses)
+        } catch {
+            print("Saving classList failed in ScheduleViewController")
         }
     }
 }


### PR DESCRIPTION
The viewWillAppear method in WatchedClassesViewController was trying to access the saved classes before the viewWillDisappear method (where classes were being saved) was being called in ScheduleViewController, thus causing the WatchedClassesViewController to be out of sync with the user's most recent selections/ removals. 

To fix this, ScheduleViewController now just resaves selections to DataStorage with every didSelect call. This could be inefficient compared to saving all at once if the user was watching a large number of classes, but that’s not likely with expected use of watching maybe 1-5 classes at a time.