### PR TITLE
Standardize notifications and move to their own file

### DIFF
--- a/BoxingScheduler.xcodeproj/project.pbxproj
+++ b/BoxingScheduler.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		FC9ECEA0277E463900097BF4 /* ColorChangingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9ECE9F277E463900097BF4 /* ColorChangingButton.swift */; };
 		FC9ECEA5277E9A2D00097BF4 /* NotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9ECEA4277E9A2D00097BF4 /* NotificationHandler.swift */; };
 		FC9ECEA72781631E00097BF4 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9ECEA62781631E00097BF4 /* WebViewController.swift */; };
+		FCCCCCDE28A55E660067DC3F /* NotificationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCCCCDD28A55E650067DC3F /* NotificationExtensions.swift */; };
 		FCD56B622759A55B00DBE45B /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = FCD56B612759A55B00DBE45B /* SwiftSoup */; };
 		FCE65FDB27A3A58700A9A675 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = FCE65FDA27A3A58700A9A675 /* FirebaseMessaging */; };
 		FCE65FE627A5BAF800A9A675 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FCE65FE527A5BAF800A9A675 /* GoogleService-Info.plist */; };
@@ -81,6 +82,7 @@
 		FC9ECE9F277E463900097BF4 /* ColorChangingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ColorChangingButton.swift; path = BoxingScheduler/Views/ColorChangingButton.swift; sourceTree = SOURCE_ROOT; };
 		FC9ECEA4277E9A2D00097BF4 /* NotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotificationHandler.swift; path = BoxingScheduler/Helpers/NotificationHandler.swift; sourceTree = SOURCE_ROOT; };
 		FC9ECEA62781631E00097BF4 /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
+		FCCCCCDD28A55E650067DC3F /* NotificationExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationExtensions.swift; sourceTree = "<group>"; };
 		FCE65FE027A44F7300A9A675 /* BoxingScheduler.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BoxingScheduler.entitlements; sourceTree = "<group>"; };
 		FCE65FE527A5BAF800A9A675 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "BoxingScheduler/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		FCF9144E2756F68700717347 /* BoxingScheduler.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoxingScheduler.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -149,6 +151,7 @@
 			children = (
 				FC9DC331276D46CA00091A31 /* Utilities.swift */,
 				FC9DC333276D499F00091A31 /* DateHandler.swift */,
+				FCCCCCDD28A55E650067DC3F /* NotificationExtensions.swift */,
 				FC9ECEA4277E9A2D00097BF4 /* NotificationHandler.swift */,
 			);
 			path = Helpers;
@@ -395,6 +398,7 @@
 				FC9DC32727698A6700091A31 /* MbaClassTableViewCell.swift in Sources */,
 				FC9DC3232769245A00091A31 /* Networking.swift in Sources */,
 				FC9DC32D276CF66400091A31 /* WatchedClassesViewController.swift in Sources */,
+				FCCCCCDE28A55E660067DC3F /* NotificationExtensions.swift in Sources */,
 				FC9DC332276D46CA00091A31 /* Utilities.swift in Sources */,
 				FC9ECE90277144F200097BF4 /* WatchedClasses.swift in Sources */,
 				FCF9148B2757086D00717347 /* SettingsFormViewController.swift in Sources */,

--- a/BoxingScheduler/AppDelegate.swift
+++ b/BoxingScheduler/AppDelegate.swift
@@ -146,6 +146,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 extension AppDelegate: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         let tokenDict = ["token": fcmToken ?? ""]
-        NotificationCenter.default.post(name: Notification.Name("FCMToken"), object: nil, userInfo: tokenDict)
+        NotificationCenter.default.post(name: .fcmToken, object: nil, userInfo: tokenDict)
     }
 }

--- a/BoxingScheduler/Helpers/NotificationExtensions.swift
+++ b/BoxingScheduler/Helpers/NotificationExtensions.swift
@@ -1,0 +1,15 @@
+//
+//  NotificationExtensions.swift
+//  BoxingScheduler
+//
+//  Created by Emily Corso on 8/11/22.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let newScheduleData = Notification.Name("com.emilykcorso.fetchScheduleData")
+    static let newAvailableClasses = Notification.Name("com.emilykcorso.fetchAvailableClasses")
+    static let classDataFetchComplete = Notification.Name("classDataFetchComplete")
+    static let fcmToken =  Notification.Name("FCMToken")
+}

--- a/BoxingScheduler/Helpers/Utilities.swift
+++ b/BoxingScheduler/Helpers/Utilities.swift
@@ -56,8 +56,3 @@ extension FileManager {
         return paths[0]
     }
 }
-
-extension Notification.Name {
-    static let newScheduleData = Notification.Name("com.emilykcorso.fetchScheduleData")
-    static let newAvailableClasses = Notification.Name("com.emilykcorso.fetchAvailableClasses")
-}


### PR DESCRIPTION
- Moves Notification.Name extension to it's own file
- Standardizes FCMToken notification name
- Does *not* change the newScheduleData and newAvailableClasses name strings because these are in the plist and might require a specific convention (TBD)