### PR TITLE
Update networking code with async/await pattern

### DIFF
--- a/BoxingScheduler.xcodeproj/project.pbxproj
+++ b/BoxingScheduler.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 35FN5AB6A3;
 				INFOPLIST_FILE = BoxingScheduler/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -614,6 +615,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 35FN5AB6A3;
 				INFOPLIST_FILE = BoxingScheduler/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/BoxingScheduler/Helpers/NotificationHandler.swift
+++ b/BoxingScheduler/Helpers/NotificationHandler.swift
@@ -29,7 +29,8 @@ class NotificationHandler {
     
     func scheduleAvailableClassNotification() {
         let watchedClasses = WatchedClasses()
-        watchedClasses.getAllClasses() { allClasses in
+        Task {
+            let allClasses = await watchedClasses.getAllClasses()
             let availableClasses = watchedClasses.getNowAvailableClasses(from: allClasses)
             
             if !availableClasses.isEmpty {
@@ -43,7 +44,7 @@ class NotificationHandler {
                 let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
                 
                 let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
-                center.add(request)
+                try? await center.add(request) // TODO: This needs testing
                 
                 print("Notification scheduled")
             } else {

--- a/BoxingScheduler/View Controllers/NowAvailableViewController.swift
+++ b/BoxingScheduler/View Controllers/NowAvailableViewController.swift
@@ -90,10 +90,11 @@ class NowAvailableViewController: UITableViewController {
     
     @objc func populateAvailableClasses() {
         let watchedClasses = WatchedClasses()
-        watchedClasses.getAllClasses() { allClassList in
+        Task {
+            let allClassList = await watchedClasses.getAllClasses()
             let nowAvailableClasses = watchedClasses.getNowAvailableClasses(from: allClassList)
             self.availableClasses = nowAvailableClasses.sorted()
-            
+
             DispatchQueue.main.async {
                 self.tableView.reloadData()
                 self.refreshControl?.endRefreshing()

--- a/BoxingScheduler/View Controllers/ScheduleViewController.swift
+++ b/BoxingScheduler/View Controllers/ScheduleViewController.swift
@@ -145,14 +145,11 @@ class ScheduleViewController: UITableViewController {
     }
     
     @objc func populateDateList() {
-        Networking.fetchScheduleData() { [self] dates in
-            // Check that dateList doesn't already contain these dates. If it doesn't, add them.
-            self.dateList += dates.filter() { !self.dateList.contains($0) }
-            DispatchQueue.main.async {
-                // Print the dateList to check for fakeAvailableClass
-//                print(dateList.first?.classes[0].date.toString(format: DateHandler.dateOutputFormat))
-                self.tableView.reloadData()
-            }
+        // TODO: Could this be making the loading slow?
+        Task { @MainActor in
+            let dates = await Networking.fetchScheduleData()
+            self.dateList += dates.filter() { !self.dateList.contains($0)}
+            self.tableView.reloadData()
         }
     }
     

--- a/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
+++ b/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
@@ -13,7 +13,7 @@ class WatchedClassesViewController: UITableViewController {
         didSet {
             if let selectedClasses = selectedClasses {
                 WatchedClasses().setCurrentWatched(selectedClasses.sorted())
-            } 
+            }
         }
     }
     
@@ -85,9 +85,12 @@ class WatchedClassesViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            let classToDelete = selectedClasses?[indexPath.row]
-            selectedClasses?.remove(at: indexPath.row)
-            tableView.deleteRows(at: [indexPath], with: .fade)
+            if let selected = selectedClasses {
+//                let classToDelete = selected[indexPath.row]
+                selectedClasses!.remove(at: indexPath.row) // safe to force unwrap because we already unwrapped this in order to get here
+                WatchedClasses().setCurrentWatched(selected)
+                tableView.deleteRows(at: [indexPath], with: .fade)
+            }
         }
     }
     
@@ -109,8 +112,8 @@ class WatchedClassesViewController: UITableViewController {
     }
     
     func populateSelectedClasses(completion: @escaping () -> ()) {
-        WatchedClasses().getCurrentWatched() { watchedClasses in
-            self.selectedClasses = watchedClasses.sorted()
+        Task {
+            self.selectedClasses = await WatchedClasses().getCurrentWatched()
             completion()
         }
     }


### PR DESCRIPTION
- Bump the target to iOS 15.0
- Update the Networking class's fetchScheduleData method to use async/ await rather than closures
- Handle how the above change affects the other functions that make use of fetchScheduleData (either making them async or moving calls into a Task block)