### PR TITLE
Fix sorting bug 

### DIFF
--- a/BoxingScheduler/Data Model/MbaClass.swift
+++ b/BoxingScheduler/Data Model/MbaClass.swift
@@ -116,11 +116,6 @@ extension MbaClass {
 
 extension MbaClass: Comparable {
     static func < (lhs: MbaClass, rhs: MbaClass) -> Bool {
-        if lhs.date < rhs.date {
-            return true
-        } else if lhs.name < rhs.name {
-                return true
-            }
-        return false
-        }
-    } 
+        return lhs.date < rhs.date
+    }
+}

--- a/BoxingScheduler/Data Model/WatchedClasses.swift
+++ b/BoxingScheduler/Data Model/WatchedClasses.swift
@@ -68,7 +68,7 @@ class WatchedClasses {
         
         let classes = await getAllClasses()
         let updatedClasses = classes.filter() { watched.contains($0) } // This updates the spotsAvailable with the most recent data
-        return updatedClasses
+        return updatedClasses.sorted()
     }
     
     func setCurrentWatched(_ newCurrent: [MbaClass]) {

--- a/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
+++ b/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
@@ -33,6 +33,8 @@ class WatchedClassesViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        self.selectedClasses = DataStorage().retrieve()?.sorted()
+        
         populateSelectedClasses() {
             DispatchQueue.main.async {
                 self.tableView.reloadData()


### PR DESCRIPTION
This PR makes some changes to how and where sorting is handled in order to reduce UI distraction (classes resorting themselves each time the view loads) and make the code cleaner overall.

- Sort MbaClasses by date/ time instead of by date and name
- Initialize the WatchedClasses list from DataStorage first, then replace that with the list that is supplied asynchronously if anything has changed