### PR TITLE
Add date section headers

### DIFF
--- a/BoxingScheduler/Data Model/ClassDate.swift
+++ b/BoxingScheduler/Data Model/ClassDate.swift
@@ -16,6 +16,11 @@ class ClassDate {
         self.classes = classes
     }
     
+    init(date: Date, classes: [MbaClass]) {
+        self.exactDate = date
+        self.classes = classes
+    }
+    
     init() {
         self.exactDate = nil
         self.classes = [MbaClass]()

--- a/BoxingScheduler/Data Model/MbaClass.swift
+++ b/BoxingScheduler/Data Model/MbaClass.swift
@@ -14,14 +14,10 @@ class MbaClass: NSObject, NSCoding {
     var date: Date = Date()
     var time: String = ""
     
-    // Keeping this commented out code for now to clarify the source of date bugs
-//    init(name: String, spotsAvailable: String, date: String) {
     init(name: String, spotsAvailable: String, date: Date) {
         super.init()
-//        let fullDate = date + " \(getStartTime(for: name))"
         self.name = name
         self.spotsAvailable = getSpotsAsInt(from: spotsAvailable)
-//        self.date = fullDate.toDate() ?? Date()
         self.date = date
     }
     

--- a/BoxingScheduler/Data Model/WatchedClasses.swift
+++ b/BoxingScheduler/Data Model/WatchedClasses.swift
@@ -60,6 +60,22 @@ class WatchedClasses {
         return orderedArray
     }
     
+    // TODO: Would be nice to refactor this as a direct fetch so that availableClasses doesn't need to be passed into it
+    func createClassDatesFromClasses(_ availableClasses: [MbaClass]?) -> [ClassDate] {
+        guard let availableClasses = availableClasses else {
+            return []
+        }
+        var classDateArray = [ClassDate]()
+        
+        let classesByDate = Dictionary(grouping: availableClasses, by: { $0.date })
+        
+        for (key, value) in classesByDate {
+            classDateArray.append(ClassDate(date: key, classes: value))
+        }
+        
+        return classDateArray.sorted()
+    }
+    
     func getCurrentWatched() async -> [MbaClass] {
         removePastClassesfromCurrent()
         guard let watched = self.current else {

--- a/BoxingScheduler/View Controllers/NowAvailableViewController.swift
+++ b/BoxingScheduler/View Controllers/NowAvailableViewController.swift
@@ -10,11 +10,14 @@ import PureLayout
 
 
 class NowAvailableViewController: UITableViewController {
+    // This is the actual date source
     var availableClasses: [MbaClass]?
+    // This creates sections in the data source
+    var classesByDate: [ClassDate]?
+    
     private let image = UIImage(systemName: "list.star")!.withRenderingMode(.alwaysTemplate)
     private let topMessage = "Now Available"
     private let bottomMessage = "You don't have any available classes yet. As classes become available they will show up here."
-    
     
     var scheduleNowButton: UIButton = {
         let floatingButton = UIButton()
@@ -52,6 +55,7 @@ class NowAvailableViewController: UITableViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         populateAvailableClasses()
+        createClassDatesFromClasses()
     }
 
     // MARK: - Table view data source
@@ -148,5 +152,22 @@ class NowAvailableViewController: UITableViewController {
     func setupEmptyBackgroundView() {
         let emptyBackgroundView = EmptyBackgroundView(image: image, top: topMessage, bottom: bottomMessage)
         tableView.backgroundView = emptyBackgroundView
+    }
+    
+    // This func is repeated wholesale from WatchedClassesViewController. Where could I put this so that both VCs have access to it and it isn't duplicated?
+    // Can pass in the datasource as an argument
+    private func createClassDatesFromClasses() -> [ClassDate] {
+        guard let availableClasses = availableClasses else {
+            return []
+        }
+        var classDateArray = [ClassDate]()
+        
+        let classesByDate = Dictionary(grouping: availableClasses, by: { $0.date })
+        
+        for (key, value) in classesByDate {
+            classDateArray.append(ClassDate(date: key, classes: value))
+        }
+        
+        return classDateArray.sorted()
     }
 }

--- a/BoxingScheduler/View Controllers/NowAvailableViewController.swift
+++ b/BoxingScheduler/View Controllers/NowAvailableViewController.swift
@@ -60,19 +60,23 @@ class NowAvailableViewController: UITableViewController {
     // MARK: - Table view data source
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        return classesByDate?.count ?? 1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if availableClasses?.count == 0 {
+        guard let classesByDate = classesByDate else {
+            return 1
+        }
+        
+        if classesByDate.count == 0 {
             tableView.separatorStyle = .none
             tableView.backgroundView?.isHidden = false
         } else {
             tableView.separatorStyle = .singleLine
             tableView.backgroundView?.isHidden = true
         }
-        
-        return availableClasses?.count ?? 0
+       
+        return classesByDate[section].classes.count
     }
 
 
@@ -81,15 +85,23 @@ class NowAvailableViewController: UITableViewController {
             return UITableViewCell()
         }
         
-        guard let availableClasses = availableClasses else {
+        guard let classesByDate = classesByDate else {
             return UITableViewCell()
         }
 
-        let mbaClass = availableClasses[indexPath.row]
+        let mbaClass = classesByDate[indexPath.section].classes[indexPath.row]
         cell.setCellText(mbaClass: mbaClass)
         
         return cell
     }
+    
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        // don't implicitly unwrap here as the datasource may be nil the first time the tableView tries to render
+        let sectionTitle = classesByDate?[section].exactDate?.toString(format: DateHandler.longOutputFormat)
+        return sectionTitle
+    }
+    
+    // MARK: - Actions
     
     @objc func populateAvailableClasses() {
         let watchedClasses = WatchedClasses()

--- a/BoxingScheduler/View Controllers/NowAvailableViewController.swift
+++ b/BoxingScheduler/View Controllers/NowAvailableViewController.swift
@@ -55,7 +55,6 @@ class NowAvailableViewController: UITableViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         populateAvailableClasses()
-        createClassDatesFromClasses()
     }
 
     // MARK: - Table view data source
@@ -98,6 +97,7 @@ class NowAvailableViewController: UITableViewController {
             let allClassList = await watchedClasses.getAllClasses()
             let nowAvailableClasses = watchedClasses.getNowAvailableClasses(from: allClassList)
             self.availableClasses = nowAvailableClasses.sorted()
+            self.classesByDate = watchedClasses.createClassDatesFromClasses(self.availableClasses)
 
             DispatchQueue.main.async {
                 self.tableView.reloadData()
@@ -152,22 +152,5 @@ class NowAvailableViewController: UITableViewController {
     func setupEmptyBackgroundView() {
         let emptyBackgroundView = EmptyBackgroundView(image: image, top: topMessage, bottom: bottomMessage)
         tableView.backgroundView = emptyBackgroundView
-    }
-    
-    // This func is repeated wholesale from WatchedClassesViewController. Where could I put this so that both VCs have access to it and it isn't duplicated?
-    // Can pass in the datasource as an argument
-    private func createClassDatesFromClasses() -> [ClassDate] {
-        guard let availableClasses = availableClasses else {
-            return []
-        }
-        var classDateArray = [ClassDate]()
-        
-        let classesByDate = Dictionary(grouping: availableClasses, by: { $0.date })
-        
-        for (key, value) in classesByDate {
-            classDateArray.append(ClassDate(date: key, classes: value))
-        }
-        
-        return classDateArray.sorted()
     }
 }

--- a/BoxingScheduler/View Controllers/ScheduleViewController.swift
+++ b/BoxingScheduler/View Controllers/ScheduleViewController.swift
@@ -66,7 +66,6 @@ class ScheduleViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         let sectionTitle = dateList[section].exactDate!.toString(format: DateHandler.longOutputFormat)
         return sectionTitle
-        
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
+++ b/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
@@ -56,16 +56,15 @@ class WatchedClassesViewController: UITableViewController {
     // MARK: - Table view data source
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        // Ideally this would ahve multiple sections sorted by date as in the previous view
-        return 1
+        return classesByDate?.count ?? 1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard let selectedClasses = selectedClasses else {
+        guard let classesByDate = classesByDate else {
             return 1
         }
         
-        if selectedClasses.count == 0 {
+        if classesByDate.count == 0 {
             tableView.separatorStyle = .none
             tableView.backgroundView?.isHidden = false
         } else {
@@ -73,7 +72,7 @@ class WatchedClassesViewController: UITableViewController {
             tableView.backgroundView?.isHidden = true
         }
        
-        return selectedClasses.count
+        return classesByDate[section].classes.count
     }
 
 
@@ -81,9 +80,9 @@ class WatchedClassesViewController: UITableViewController {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: WatchedClassesCell.identifier, for: indexPath) as? WatchedClassesCell else {
             return UITableViewCell()
         }
-        
-        if let selected = selectedClasses {
-            let mbaClass = selected[indexPath.row]
+
+        if let classesByDate = classesByDate {
+            let mbaClass = classesByDate[indexPath.section].classes[indexPath.row]
             cell.setCellText(mbaClass: mbaClass)
         }
         
@@ -92,12 +91,20 @@ class WatchedClassesViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            if let selected = selectedClasses {
-//                let classToDelete = selected[indexPath.row]
-                selectedClasses!.remove(at: indexPath.row) // safe to force unwrap because we already unwrapped this in order to get here
-                WatchedClasses().setCurrentWatched(selected)
-                tableView.deleteRows(at: [indexPath], with: .fade)
+            guard let selected = selectedClasses else {
+                return
             }
+            
+            guard let dateList = classesByDate else {
+                return
+            }
+            
+            let mbaClass = dateList[indexPath.section].classes[indexPath.row]
+            selectedClasses!.remove(at: selected.firstIndex(of: mbaClass)!) // Safe to force unwrap selected and firstIndex(of:) here
+            WatchedClasses().setCurrentWatched(selectedClasses!)
+            classesByDate![indexPath.section].classes.remove(at: indexPath.row)
+            
+            tableView.deleteRows(at: [indexPath], with: .fade)
         }
     }
     

--- a/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
+++ b/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
@@ -41,7 +41,7 @@ class WatchedClassesViewController: UITableViewController {
         
         populateSelectedClasses() {
             DispatchQueue.main.async {
-                self.classesByDate = self.createClassDatesFromClasses()
+                self.classesByDate = WatchedClasses().createClassDatesFromClasses(self.selectedClasses) // should the top of the class have a shared reference to watchedClasses instead?
                 self.tableView.reloadData()
             }
         }
@@ -116,22 +116,6 @@ class WatchedClassesViewController: UITableViewController {
     }
     
     // MARK: - Actions
-    
-    private func createClassDatesFromClasses() -> [ClassDate] {
-        guard let selectedClasses = selectedClasses else {
-            return []
-        }
-        var classDateArray = [ClassDate]()
-        
-        let classesByDate = Dictionary(grouping: selectedClasses, by: { $0.date })
-        
-        for (key, value) in classesByDate {
-            classDateArray.append(ClassDate(date: key, classes: value))
-        }
-        
-        return classDateArray.sorted()
-    }
-    
     func configureRefreshControl() {
         tableView.refreshControl = UIRefreshControl()
         tableView.addSubview(refreshControl!)

--- a/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
+++ b/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import Combine
 
 class WatchedClassesViewController: UITableViewController {
+    // This is the actual date source
     var selectedClasses: [MbaClass]? {
         didSet {
             if let selectedClasses = selectedClasses {
@@ -16,6 +17,9 @@ class WatchedClassesViewController: UITableViewController {
             }
         }
     }
+    
+    // This creates sections in the data source
+    var classesByDate: [ClassDate]?
     
     private let image = UIImage(systemName: "eye")!.withRenderingMode(.alwaysTemplate)
     private let topMessage = "Watched Classes"
@@ -37,6 +41,7 @@ class WatchedClassesViewController: UITableViewController {
         
         populateSelectedClasses() {
             DispatchQueue.main.async {
+                self.classesByDate = self.createClassDatesFromClasses()
                 self.tableView.reloadData()
             }
         }
@@ -94,6 +99,12 @@ class WatchedClassesViewController: UITableViewController {
                 tableView.deleteRows(at: [indexPath], with: .fade)
             }
         }
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        // don't implicitly unwrap here as the datasource may be nil the first time the tableView tries to render
+        let sectionTitle = classesByDate?[section].exactDate?.toString(format: DateHandler.longOutputFormat)
+        return sectionTitle
     }
     
     // MARK: - Actions

--- a/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
+++ b/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
@@ -98,6 +98,21 @@ class WatchedClassesViewController: UITableViewController {
     
     // MARK: - Actions
     
+    private func createClassDatesFromClasses() -> [ClassDate] {
+        guard let selectedClasses = selectedClasses else {
+            return []
+        }
+        var classDateArray = [ClassDate]()
+        
+        let classesByDate = Dictionary(grouping: selectedClasses, by: { $0.date })
+        
+        for (key, value) in classesByDate {
+            classDateArray.append(ClassDate(date: key, classes: value))
+        }
+        
+        return classDateArray.sorted()
+    }
+    
     func configureRefreshControl() {
         tableView.refreshControl = UIRefreshControl()
         tableView.addSubview(refreshControl!)

--- a/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
+++ b/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
@@ -99,8 +99,9 @@ class WatchedClassesViewController: UITableViewController {
                 return
             }
             
+            // Safe to force unwrap selectedClasses and classesByDate going forward
             let mbaClass = dateList[indexPath.section].classes[indexPath.row]
-            selectedClasses!.remove(at: selected.firstIndex(of: mbaClass)!) // Safe to force unwrap selected and firstIndex(of:) here
+            selectedClasses!.remove(at: selected.firstIndex(of: mbaClass)!)
             WatchedClasses().setCurrentWatched(selectedClasses!)
             classesByDate![indexPath.section].classes.remove(at: indexPath.row)
             


### PR DESCRIPTION
This gives WatchedClasses a method to create a list of ClassDates from a list of MbaClasses, which makes it possible to generate an array of ClassDates as a tableView datasource. Then the date of each ClassDate can function as the tableView section header and the list of classes gives the cells for each section. This is superior to using a dictionary with dates and class lists for each date as the ClassDate object already existed and can be sorted (with custom sorting implementation).

With this in place, this branch adds section headers by date to the Watched Classes and Now Available view controllers.