### PR TITLE
Fix WatchedClasses Not Updating

### DIFF
--- a/BoxingScheduler/Data Model/ClassType.swift
+++ b/BoxingScheduler/Data Model/ClassType.swift
@@ -8,24 +8,32 @@
 import Foundation
 
 struct ClassType {
-    //give raw values that are strings for the class names, then create an getStartTime() func that switches over these are returns a time for each (time should be formatted with the dateFormatter eventually, but could be a string to start)
-    case morningBodyBlastMondays = "Morning Body Blast Mondays (With Permission Only)"
-    case footworkFundamentalsMondays = "Footwork FUNdamentals"
-    case advancedFootwork = "Advanced Footwork (With Permission Only)"
-    case lunchTimeBoxingPowerHourTuesdays = "Lunch-Time Boxing Power Hour Tuesdays"
-    case cardioBoxingTuesdays5 = "Cardio Boxing Tuesdays (5pm)"
-    case cardioBoxingTuesdays615 = "Cardio Boxing Tuesdays (6:15pm)"
-    case boxingSkillsTuesdays = "Boxing Skills Tuesdays (With Permission Only)"
-    case morningBodyBlastWednesdays = "Morning Body Blast Wednesdays (With Permission Only)"
-    case combatConditioningWednesdays = "Combat Conditioning Wednesdays"
-    case TeamPracticeWednesdays = "Team Practice Wednesdays (With Permission Only)"
-    case lunchTimeBoxingPowerHourThursdays = "Lunch-Time Boxing Power Hour Thursdays"
-    case cardioBoxingThursdays5 = "Cardio Boxing Thursdays (5pm)"
-    case cardioBoxingThursdays615 = "Cardio Boxing Thursdays (6:15pm)"
-    case boxingSkillsThursdays = "Boxing Skills Thursdays (With Permission Only)"
-    case morningBodyBlastFridays = "Morning Body Blast Fridays (With Permission Only)"
-    case combatConditioningFridays = "Combat Conditioning Fridays"
-    case teamPracticeFridays = "Team Practice Fridays (With Permission Only)"
-    case cardioBoxingSaturdays9 = "Cardio Boxing Saturdays (9am)"
-    case cardioBoxingSaturdays1030 = "Cardio Boxing Saturdays (10:30am)"
+    let name: Name?
+    
+    init(name: Name?) {
+        self.name = name
+    }
+    
+    enum Name: String {
+        case morningBodyBlastMondays = "Morning Body Blast Mondays (With Permission Only)"
+        case footworkFundamentalsMondays = "Footwork FUNdamentals"
+        case advancedFootwork = "Advanced Footwork (With Permission Only)"
+        case lunchTimeBoxingPowerHourTuesdays = "Lunch-Time Boxing Power Hour Tuesdays"
+        case cardioBoxingTuesdays5 = "Cardio Boxing Tuesdays (5pm)"
+        case cardioBoxingTuesdays615 = "Cardio Boxing Tuesdays (6:15pm)"
+        case boxingSkillsTuesdays = "Boxing Skills Tuesdays (With Permission Only)"
+        case morningBodyBlastWednesdays = "Morning Body Blast Wednesdays (With Permission Only)"
+        case combatConditioningWednesdays = "Combat Conditioning Wednesdays"
+        case TeamPracticeWednesdays = "Team Practice Wednesdays (With Permission Only)"
+        case lunchTimeBoxingPowerHourThursdays = "Lunch-Time Boxing Power Hour Thursdays"
+        case cardioBoxingThursdays5 = "Cardio Boxing Thursdays (5pm)"
+        case cardioBoxingThursdays615 = "Cardio Boxing Thursdays (6:15pm)"
+        case boxingSkillsThursdays = "Boxing Skills Thursdays (With Permission Only)"
+        case morningBodyBlastFridays = "Morning Body Blast Fridays (With Permission Only)"
+        case combatConditioningFridays = "Combat Conditioning Fridays"
+        case teamPracticeFridays = "Team Practice Fridays (With Permission Only)"
+        case cardioBoxingSaturdays9 = "Cardio Boxing Saturdays (9am)"
+        case cardioBoxingSaturdays1030 = "Cardio Boxing Saturdays (10:30am)"
+    }
+    
 }

--- a/BoxingScheduler/Data Model/ClassType.swift
+++ b/BoxingScheduler/Data Model/ClassType.swift
@@ -8,10 +8,12 @@
 import Foundation
 
 struct ClassType {
-    let name: Name?
+    let name: Name!
+    var startTime: ClassTime = ClassTime(hours: 0, minutes: 0, seconds: 0)
     
-    init(name: Name?) {
+    init(name: Name) {
         self.name = name
+        self.startTime = getStartTime(for: name)
     }
     
     enum Name: String {

--- a/BoxingScheduler/Data Model/ClassType.swift
+++ b/BoxingScheduler/Data Model/ClassType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum ClassType: String {
+struct ClassType {
     //give raw values that are strings for the class names, then create an getStartTime() func that switches over these are returns a time for each (time should be formatted with the dateFormatter eventually, but could be a string to start)
     case morningBodyBlastMondays = "Morning Body Blast Mondays (With Permission Only)"
     case footworkFundamentalsMondays = "Footwork FUNdamentals"

--- a/BoxingScheduler/Data Model/ClassType.swift
+++ b/BoxingScheduler/Data Model/ClassType.swift
@@ -36,4 +36,17 @@ struct ClassType {
         case cardioBoxingSaturdays1030 = "Cardio Boxing Saturdays (10:30am)"
     }
     
+    
+}
+
+struct ClassTime {
+    var hours: Int = 0
+    var minutes: Int = 0
+    var seconds: Int = 0
+    
+    init(hours: Int, minutes: Int, seconds: Int) {
+        self.hours = hours
+        self.minutes = minutes
+        self.seconds = seconds
+    }
 }

--- a/BoxingScheduler/Data Model/ClassType.swift
+++ b/BoxingScheduler/Data Model/ClassType.swift
@@ -36,7 +36,52 @@ struct ClassType {
         case cardioBoxingSaturdays1030 = "Cardio Boxing Saturdays (10:30am)"
     }
     
-    
+    func getStartTime(for className: String) -> String {
+        // Rather than elaborate parsing, use the Name enum and give them associated values, then just switch over those returning the appropriate time. Pros: more readable. Cons: more brittle, less "cool"
+        switch className {
+        case Name.morningBodyBlastMondays.rawValue:
+            return "06:30"
+        case Name.footworkFundamentalsMondays.rawValue:
+            return "17:00"
+        case Name.advancedFootwork.rawValue:
+            // return "6:15pm" // Time format is incorrect
+            return "18:15"
+        case Name.lunchTimeBoxingPowerHourTuesdays.rawValue:
+            return "12:00"
+        case Name.cardioBoxingTuesdays5.rawValue:
+            return "17:00"
+        case Name.cardioBoxingTuesdays615.rawValue:
+            return "18:15"
+        case Name.boxingSkillsTuesdays.rawValue:
+            return "19:15"
+        case Name.morningBodyBlastWednesdays.rawValue:
+            return "06:30"
+        case Name.combatConditioningWednesdays.rawValue:
+            return "17:00"
+        case Name.TeamPracticeWednesdays.rawValue:
+            return "18:00"
+        case Name.lunchTimeBoxingPowerHourThursdays.rawValue:
+            return "12:00"
+        case Name.cardioBoxingThursdays5.rawValue:
+            return "17:00"
+        case Name.cardioBoxingThursdays615.rawValue:
+            return "18:15"
+        case Name.boxingSkillsThursdays.rawValue:
+            return "19:15"
+        case Name.morningBodyBlastFridays.rawValue:
+            return "06:30"
+        case Name.combatConditioningFridays.rawValue:
+            return "17:00"
+        case Name.teamPracticeFridays.rawValue:
+            return "18:00"
+        case Name.cardioBoxingSaturdays9.rawValue:
+            return "09:00"
+        case Name.cardioBoxingSaturdays1030.rawValue:
+            return "10:15"
+        default:
+            return "12:00"
+        }
+    }
 }
 
 struct ClassTime {

--- a/BoxingScheduler/Data Model/ClassType.swift
+++ b/BoxingScheduler/Data Model/ClassType.swift
@@ -36,50 +36,49 @@ struct ClassType {
         case cardioBoxingSaturdays1030 = "Cardio Boxing Saturdays (10:30am)"
     }
     
-    func getStartTime(for className: String) -> String {
+    func getStartTime(for className: Name) -> ClassTime {
         // Rather than elaborate parsing, use the Name enum and give them associated values, then just switch over those returning the appropriate time. Pros: more readable. Cons: more brittle, less "cool"
         switch className {
-        case Name.morningBodyBlastMondays.rawValue:
-            return "06:30"
-        case Name.footworkFundamentalsMondays.rawValue:
-            return "17:00"
-        case Name.advancedFootwork.rawValue:
-            // return "6:15pm" // Time format is incorrect
-            return "18:15"
-        case Name.lunchTimeBoxingPowerHourTuesdays.rawValue:
-            return "12:00"
-        case Name.cardioBoxingTuesdays5.rawValue:
-            return "17:00"
-        case Name.cardioBoxingTuesdays615.rawValue:
-            return "18:15"
-        case Name.boxingSkillsTuesdays.rawValue:
-            return "19:15"
-        case Name.morningBodyBlastWednesdays.rawValue:
-            return "06:30"
-        case Name.combatConditioningWednesdays.rawValue:
-            return "17:00"
-        case Name.TeamPracticeWednesdays.rawValue:
-            return "18:00"
-        case Name.lunchTimeBoxingPowerHourThursdays.rawValue:
-            return "12:00"
-        case Name.cardioBoxingThursdays5.rawValue:
-            return "17:00"
-        case Name.cardioBoxingThursdays615.rawValue:
-            return "18:15"
-        case Name.boxingSkillsThursdays.rawValue:
-            return "19:15"
-        case Name.morningBodyBlastFridays.rawValue:
-            return "06:30"
-        case Name.combatConditioningFridays.rawValue:
-            return "17:00"
-        case Name.teamPracticeFridays.rawValue:
-            return "18:00"
-        case Name.cardioBoxingSaturdays9.rawValue:
-            return "09:00"
-        case Name.cardioBoxingSaturdays1030.rawValue:
-            return "10:15"
+        case Name.morningBodyBlastMondays:
+            return ClassTime(hours: 6, minutes: 30, seconds: 0)
+        case Name.footworkFundamentalsMondays:
+            return ClassTime(hours: 17, minutes: 0, seconds: 0)
+        case Name.advancedFootwork:
+            return ClassTime(hours: 18, minutes: 15, seconds: 0)
+        case Name.lunchTimeBoxingPowerHourTuesdays:
+            return ClassTime(hours: 12, minutes: 0, seconds: 0)
+        case Name.cardioBoxingTuesdays5:
+            return ClassTime(hours: 17, minutes: 0, seconds: 0)
+        case Name.cardioBoxingTuesdays615:
+            return ClassTime(hours: 18, minutes: 15, seconds: 0)
+        case Name.boxingSkillsTuesdays:
+            return ClassTime(hours: 19, minutes: 15, seconds: 0)
+        case Name.morningBodyBlastWednesdays:
+            return ClassTime(hours: 6, minutes: 30, seconds: 0)
+        case Name.combatConditioningWednesdays:
+            return ClassTime(hours: 17, minutes: 0, seconds: 0)
+        case Name.TeamPracticeWednesdays:
+            return ClassTime(hours: 18, minutes: 0, seconds: 0)
+        case Name.lunchTimeBoxingPowerHourThursdays:
+            return ClassTime(hours: 12, minutes: 0, seconds: 0)
+        case Name.cardioBoxingThursdays5:
+            return ClassTime(hours: 17, minutes: 0, seconds: 0)
+        case Name.cardioBoxingThursdays615:
+            return ClassTime(hours: 18, minutes: 15, seconds: 0)
+        case Name.boxingSkillsThursdays:
+            return ClassTime(hours: 19, minutes: 15, seconds: 0)
+        case Name.morningBodyBlastFridays:
+            return ClassTime(hours: 6, minutes: 30, seconds: 0)
+        case Name.combatConditioningFridays:
+            return ClassTime(hours: 17, minutes: 0, seconds: 0)
+        case Name.teamPracticeFridays:
+            return ClassTime(hours: 18, minutes: 0, seconds: 0)
+        case Name.cardioBoxingSaturdays9:
+            return ClassTime(hours: 9, minutes: 0, seconds: 0)
+        case Name.cardioBoxingSaturdays1030:
+            return ClassTime(hours: 10, minutes: 15, seconds: 0)
         default:
-            return "12:00"
+            return ClassTime(hours: 0, minutes: 0, seconds: 0)
         }
     }
 }

--- a/BoxingScheduler/Data Model/MbaClass.swift
+++ b/BoxingScheduler/Data Model/MbaClass.swift
@@ -56,51 +56,6 @@ class MbaClass: NSObject, NSCoding {
         return spotsInt
     }
     
-    private func getStartTime(for className: String) -> String {
-        // Rather than eleaborate parsing, use the ClassType enum and give them associated values, then just switch over those returning the appropriate time. Pros: more readable. Cons: more brittle, less "cool"
-        switch className {
-        case ClassType.morningBodyBlastMondays.rawValue:
-            return "06:30"
-        case ClassType.footworkFundamentalsMondays.rawValue:
-            return "17:00"
-        case ClassType.advancedFootwork.rawValue:
-            return "6:15pm"
-        case ClassType.lunchTimeBoxingPowerHourTuesdays.rawValue:
-            return "12:00"
-        case ClassType.cardioBoxingTuesdays5.rawValue:
-            return "17:00"
-        case ClassType.cardioBoxingTuesdays615.rawValue:
-            return "18:15"
-        case ClassType.boxingSkillsTuesdays.rawValue:
-            return "19:15"
-        case ClassType.morningBodyBlastWednesdays.rawValue:
-            return "06:30"
-        case ClassType.combatConditioningWednesdays.rawValue:
-            return "17:00"
-        case ClassType.TeamPracticeWednesdays.rawValue:
-            return "18:00"
-        case ClassType.lunchTimeBoxingPowerHourThursdays.rawValue:
-            return "12:00"
-        case ClassType.cardioBoxingThursdays5.rawValue:
-            return "17:00"
-        case ClassType.cardioBoxingThursdays615.rawValue:
-            return "18:15"
-        case ClassType.boxingSkillsThursdays.rawValue:
-            return "19:15"
-        case ClassType.morningBodyBlastFridays.rawValue:
-            return "06:30"
-        case ClassType.combatConditioningFridays.rawValue:
-            return "17:00"
-        case ClassType.teamPracticeFridays.rawValue:
-            return "18:00"
-        case ClassType.cardioBoxingSaturdays9.rawValue:
-            return "09:00"
-        case ClassType.cardioBoxingSaturdays1030.rawValue:
-            return "10:15"
-        default:
-            return "12:00"
-        }
-    }
 }
 
 extension MbaClass {

--- a/BoxingScheduler/Helpers/DateHandler.swift
+++ b/BoxingScheduler/Helpers/DateHandler.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct DateHandler {
     static let dateInputFormat = "MMM d, yyyy HH:mm"
-    static let mdyDateInputFormat = "MMMM d, yyyy"
+    static let mdyDateInputFormat = "MMMM d, yyyy" // Note this will produce dates initialized to noon on this day
     static let shortOutputFormat = "MMM d h:mm a"
     static let longOutputFormat = "EEEE, MMM d, yyyy"
     

--- a/BoxingScheduler/Networking/Networking.swift
+++ b/BoxingScheduler/Networking/Networking.swift
@@ -105,11 +105,18 @@ class Networking {
                     let spotsAvailable = try elements[index + 1].select(".class-spots").text()
                     
                     // Format the date to include time
-                    let date = dateArray.last?.exactDate ?? Date() // This will be the correct date, but set to noon by default because it is initialized above with mdyDateInputFormat
-                    let startTime = ClassType(name: ClassType.Name(rawValue: name)!).startTime
-                    let betterDate = Calendar.current.date(bySettingHour: startTime.hours, minute: startTime.minutes, second: startTime.seconds, of: date) ?? Date()
+                    var date = dateArray.last?.exactDate ?? Date() // This will be the correct date, but set to noon by default because it is initialized above with mdyDateInputFormat
                     
-                    let boxingClass = MbaClass(name: name, spotsAvailable: spotsAvailable, date: betterDate)
+                    if let classByName = ClassType.Name(rawValue: name) {
+                        let startTime = ClassType(name: classByName).startTime
+                        date = Calendar.current.date(bySettingHour: startTime.hours, minute: startTime.minutes, second: startTime.seconds, of: date) ?? Date()
+                    } else {
+                        // Let's use a log here instead so that if the class name isn't part of the enum in ClassType (that is, if the schedule changes) we can find out about it
+                        print("This class name is not recognized, therefore the time is incorrect too. This likely indicates a change in the schedule.")
+                    }
+                    
+                    print(date.toString(format: DateHandler.shortOutputFormat))
+                    let boxingClass = MbaClass(name: name, spotsAvailable: spotsAvailable, date: date)
                     if let previousDate = dateArray.last {
                         previousDate.classes.append(boxingClass)
                     }

--- a/BoxingScheduler/Networking/Networking.swift
+++ b/BoxingScheduler/Networking/Networking.swift
@@ -103,8 +103,13 @@ class Networking {
                 } else if try! item.className().contains("class-row-xs") {
                     let name = try item.select(".class-name").text()
                     let spotsAvailable = try elements[index + 1].select(".class-spots").text()
-                    let date = dateArray.last?.exactDate ?? Date() // I think this is breaking something
-                    let boxingClass = MbaClass(name: name, spotsAvailable: spotsAvailable, date: date)
+                    
+                    // Format the date to include time
+                    let date = dateArray.last?.exactDate ?? Date() // This will be the correct date, but set to noon by default because it is initialized above with mdyDateInputFormat
+                    let startTime = ClassType(name: ClassType.Name(rawValue: name)!).startTime
+                    let betterDate = Calendar.current.date(bySettingHour: startTime.hours, minute: startTime.minutes, second: startTime.seconds, of: date) ?? Date()
+                    
+                    let boxingClass = MbaClass(name: name, spotsAvailable: spotsAvailable, date: betterDate)
                     if let previousDate = dateArray.last {
                         previousDate.classes.append(boxingClass)
                     }


### PR DESCRIPTION
This fixes a bug where the WatchedClasses tab was accidentally filtering out classes that were taking place the same day. This was because all the classes were given a default time of noon upon fetching (though this was easy to miss initially because the class name string still gives the correct time). 

To remedy this, I changed ClassType from an enum of names to a struct that could associate a class name with its correct start time right from creation after processing the data received from the network request. This is inherently brittle and could break when the schedule changes, but it is necessary because the way that the html is parsed doesn't easily provide a class time.

I've tested this both by printing out the class times as they are created (they were previously all set to noon by default, but now show the correct times) and by inserting a class with no available spots into the schedule so that it could be selected.
