### PR TITLE
Update data with remote push

### DIFF
--- a/BoxingScheduler/AppDelegate.swift
+++ b/BoxingScheduler/AppDelegate.swift
@@ -79,7 +79,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        
+        print("Received remote notification!")
+
         Task {
             let schedule = await Networking.fetchScheduleData()
             NotificationCenter.default.post(name: .newScheduleData, object: self, userInfo: ["schedule": schedule])
@@ -107,14 +108,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
         */
         
-        print("Received remote notification!")
+//        print("Received remote notification!")
     }
     
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        // This gets called when a notification is tapped (even if the app is in the background)
+//        print("DidReceive without fetchCompletionHandler was called (prob in foreground)")
         completionHandler()
     }
     
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+//        print("WillPresent was called")
+        // This got called by a non-silent notification when the app was foregrounded
         completionHandler([.banner, .badge, .sound])
     }
     

--- a/BoxingScheduler/AppDelegate.swift
+++ b/BoxingScheduler/AppDelegate.swift
@@ -184,8 +184,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             let newAvailable = watchedClasses.filterForNowAvailableClasses(from: allClasses) // does this update nowAvailable?
             let previousAvailable = DataStorage().retrieveNowAvailable() ?? []
             
-            if newAvailable != previousAvailable { // this check is too simple, will need to check nowAvailable against a version of previous available that is first filtered for classes that have passed. Leaving it for now because it helps with testing
+            // remove classes that have passed
+            let now = Date()
+            let previousAvailableWithPastClassesRemoved = previousAvailable.filter() { $0.date >= now }
+            
+            if newAvailable != previousAvailableWithPastClassesRemoved {
                 
+                // Note that this will be triggered every time the push notification is received (prob hourly) as long as a watched class is available
+                // The user will need to remove the watched class in order to stop triggering the notification (with or without signing up for it)
                 NotificationHandler().scheduleAvailableClassNotification()
                 
                 do {

--- a/BoxingScheduler/AppDelegate.swift
+++ b/BoxingScheduler/AppDelegate.swift
@@ -104,7 +104,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 
                 NotificationHandler().scheduleAvailableClassNotification()
                 
-                // Should I save this directly, or use a setter on WatchedClasses()?
                 do {
                     // save nowAvailable so the next time this get's triggered it will be the correct nowAvailable list
                     try DataStorage().saveNowAvailable(newAvailable)

--- a/BoxingScheduler/AppDelegate.swift
+++ b/BoxingScheduler/AppDelegate.swift
@@ -181,7 +181,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 }
             }
             
-            let newAvailable = watchedClasses.filterForNowAvailableClasses(from: allClasses) // does this update nowAvailable?
+            let newAvailable = watchedClasses.filterForNowAvailableClasses(from: allClasses)
             let previousAvailable = DataStorage().retrieveNowAvailable() ?? []
             
             // remove classes that have passed
@@ -190,20 +190,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             
             if newAvailable != previousAvailableWithPastClassesRemoved {
                 
-                // Note that this will be triggered every time the push notification is received (prob hourly) as long as a watched class is available
-                // The user will need to remove the watched class in order to stop triggering the notification (with or without signing up for it)
                 NotificationHandler().scheduleAvailableClassNotification()
                 
                 do {
-                    // save nowAvailable so the next time this get's triggered it will be the correct nowAvailable list
                     try DataStorage().saveNowAvailable(newAvailable)
                 } catch {
                     print("Saving failed")
                 }
             }
-            
-            // Is this necessary at all? I think the notificationHandler call above is what is actually triggering the local notification
-//            NotificationCenter.default.post(name: .newScheduleData, object: self, userInfo: ["schedule": schedule])
 
             completion()
         }

--- a/BoxingScheduler/AppDelegate.swift
+++ b/BoxingScheduler/AppDelegate.swift
@@ -97,7 +97,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 }
             }
             
-            let newAvailable = watchedClasses.getNowAvailableClasses(from: allClasses) // does this update nowAvailable?
+            let newAvailable = watchedClasses.filterForNowAvailableClasses(from: allClasses) // does this update nowAvailable?
             let previousAvailable = DataStorage().retrieveNowAvailable() ?? []
             
             if newAvailable != previousAvailable { // this check is too simple, will need to check nowAvailable against a version of previous available that is first filtered for classes that have passed. Leaving it for now because it helps with testing
@@ -191,7 +191,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     
     func getAvailableClassCount() async -> Int {
         let allClassList = await WatchedClasses().getAllClasses()
-        let nowAvailableClassCount = WatchedClasses().getNowAvailableClasses(from: allClassList).count
+        let nowAvailableClassCount = WatchedClasses().filterForNowAvailableClasses(from: allClassList).count
         
         if nowAvailableClassCount >= 1 {
             return nowAvailableClassCount

--- a/BoxingScheduler/AppDelegate.swift
+++ b/BoxingScheduler/AppDelegate.swift
@@ -165,7 +165,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
 extension AppDelegate: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        let tokenDict = ["token": fcmToken ?? ""]
+        var tokenDict = ["token": ""]
+        if let unwrappedToken = fcmToken {
+            tokenDict = ["token": unwrappedToken]
+        } else {
+            // This should be a log
+            print("fcmToken was nil!")
+        }
+        
+//        print("Token = \(fcmToken)")
         NotificationCenter.default.post(name: .fcmToken, object: nil, userInfo: tokenDict)
     }
 }

--- a/BoxingScheduler/Data Model/DataStorage.swift
+++ b/BoxingScheduler/Data Model/DataStorage.swift
@@ -8,6 +8,36 @@
 import Foundation
 
 struct DataStorage {
+    // Let's re-write this with generics so that these methods don't duplicate so much code, or maybe switch to using CoreData, or use UserDefaults to persist data using keys/ values instead
+    
+    func saveNowAvailable(_ classList: [MbaClass]) throws {
+        let fileManager = FileManager()
+        let url = fileManager.getDocumentsDirectory().appendingPathComponent("nowAvailable.txt")
+
+        do {
+            let data = try NSKeyedArchiver.archivedData(withRootObject: classList, requiringSecureCoding: false)
+            try data.write(to: url)
+        } catch {
+            print("save failed")
+        }
+    }
+
+    func retrieveNowAvailable() -> [MbaClass]? {
+        let fileManager = FileManager()
+        let url = fileManager.getDocumentsDirectory().appendingPathComponent("nowAvailable.txt")
+
+        do {
+            let data = try Data(contentsOf: url)
+            if let decodedData = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? [MbaClass] {
+                return decodedData
+            }
+        } catch {
+            return nil
+        }
+        return nil
+    }
+    
+    
     func save(_ classList: [MbaClass]) throws {
         let fileManager = FileManager()
         let url = fileManager.getDocumentsDirectory().appendingPathComponent("classList.txt")

--- a/BoxingScheduler/Data Model/DataStorage.swift
+++ b/BoxingScheduler/Data Model/DataStorage.swift
@@ -37,8 +37,7 @@ struct DataStorage {
         return nil
     }
     
-    
-    func save(_ classList: [MbaClass]) throws {
+    func saveWatched(_ classList: [MbaClass]) throws {
         let fileManager = FileManager()
         let url = fileManager.getDocumentsDirectory().appendingPathComponent("classList.txt")
         
@@ -50,7 +49,7 @@ struct DataStorage {
         }
     }
     
-    func retrieve() -> [MbaClass]? {
+    func retrieveWatched() -> [MbaClass]? {
         let fileManager = FileManager()
         let url = fileManager.getDocumentsDirectory().appendingPathComponent("classList.txt")
         

--- a/BoxingScheduler/Data Model/WatchedClasses.swift
+++ b/BoxingScheduler/Data Model/WatchedClasses.swift
@@ -10,7 +10,7 @@ import Foundation
 class WatchedClasses {
     private var current: [MbaClass]? {
         didSet {
-            // Re-save the current list anytime it is updated (for instance by the methods that remove past/ available classes as those arrays are computed
+            // Re-save the current list anytime it is updated (for instance by the methods that remove past/ available classes as those arrays are computed)
             if let current = current {
                 do {
                     try DataStorage().save(current)
@@ -20,9 +20,24 @@ class WatchedClasses {
             }
         }
     }
+    
+    private var nowAvailable: [MbaClass]? {
+        didSet {
+            // Re-save the current list anytime it is updated
+            if let available = nowAvailable {
+                do {
+                    try DataStorage().saveNowAvailable(available)
+                } catch {
+                    print("saving current classes failed")
+                }
+            }
+        }
+    }
+    
         
     init() {
         self.current = DataStorage().retrieve() ?? []
+        self.nowAvailable = DataStorage().retrieveNowAvailable() ?? []
     }
     
     func getAllClasses() async -> [MbaClass] {

--- a/BoxingScheduler/Data Model/WatchedClasses.swift
+++ b/BoxingScheduler/Data Model/WatchedClasses.swift
@@ -13,7 +13,7 @@ class WatchedClasses {
             // Re-save the current list anytime it is updated (for instance by the methods that remove past/ available classes as those arrays are computed)
             if let current = current {
                 do {
-                    try DataStorage().save(current)
+                    try DataStorage().saveWatched(current)
                 } catch {
                     print("saving current classes failed")
                 }
@@ -36,8 +36,8 @@ class WatchedClasses {
     
         
     init() {
-        self.current = DataStorage().retrieve() ?? []
-        self.nowAvailable = DataStorage().retrieveNowAvailable() ?? []
+        self.current = DataStorage().retrieveWatched() ?? []
+//        self.nowAvailable = DataStorage().retrieveNowAvailable() ?? []
     }
     
     func getAllClasses() async -> [MbaClass] {

--- a/BoxingScheduler/Data Model/WatchedClasses.swift
+++ b/BoxingScheduler/Data Model/WatchedClasses.swift
@@ -106,6 +106,14 @@ class WatchedClasses {
         self.current = newCurrent
     }
     
+    // Returns the current available class list without taping the network to update it first
+    func retrieveNowAvailableWithoutUpdate() -> [MbaClass] {
+        guard let available = self.nowAvailable else {
+            return []
+        }
+        return available
+    }
+    
     private func removePastClassesfromCurrent() {
         guard let watched = self.current else {
             return

--- a/BoxingScheduler/Data Model/WatchedClasses.swift
+++ b/BoxingScheduler/Data Model/WatchedClasses.swift
@@ -20,24 +20,9 @@ class WatchedClasses {
             }
         }
     }
-    
-    private var nowAvailable: [MbaClass]? {
-        didSet {
-            // Re-save the current list anytime it is updated
-            if let available = nowAvailable {
-                do {
-                    try DataStorage().saveNowAvailable(available)
-                } catch {
-                    print("saving current classes failed")
-                }
-            }
-        }
-    }
-    
         
     init() {
         self.current = DataStorage().retrieveWatched() ?? []
-//        self.nowAvailable = DataStorage().retrieveNowAvailable() ?? []
     }
     
     func getAllClasses() async -> [MbaClass] {
@@ -105,14 +90,6 @@ class WatchedClasses {
     
     func setCurrentWatched(_ newCurrent: [MbaClass]) {
         self.current = newCurrent
-    }
-    
-    // Returns the current available class list without taping the network to update it first
-    func retrieveNowAvailableWithoutUpdate() -> [MbaClass] {
-        guard let available = self.nowAvailable else {
-            return []
-        }
-        return available
     }
     
     private func removePastClassesfromCurrent() {

--- a/BoxingScheduler/Data Model/WatchedClasses.swift
+++ b/BoxingScheduler/Data Model/WatchedClasses.swift
@@ -52,7 +52,7 @@ class WatchedClasses {
         return classList
     }
     
-    func getNowAvailableClasses(from allClasses: [MbaClass]) -> [MbaClass] {
+    func filterForNowAvailableClasses(from allClasses: [MbaClass]) -> [MbaClass] {
         guard let watched = self.current else {
             return [MbaClass]()
         }
@@ -68,6 +68,7 @@ class WatchedClasses {
             }
         }
         
+        // Note that updating the saved current property is a side-effect of calling this method
         self.current = watched
         
         let orderedArray = Array(Set(availableClasses))

--- a/BoxingScheduler/Helpers/NotificationHandler.swift
+++ b/BoxingScheduler/Helpers/NotificationHandler.swift
@@ -30,26 +30,17 @@ class NotificationHandler {
     func scheduleAvailableClassNotification() {
         let watchedClasses = WatchedClasses()
         Task {
-            let allClasses = await watchedClasses.getAllClasses()
-            let availableClasses = watchedClasses.getNowAvailableClasses(from: allClasses)
-            
-            if !availableClasses.isEmpty {
                 let center = UNUserNotificationCenter.current()
                 center.removeAllPendingNotificationRequests()
                 
                 let content = UNMutableNotificationContent()
+                // TODO: Create custom content for this depending on the class
                 content.title = "Class Available"
                 content.body = "Go to MBA website to sign up"
-                
-                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
-                
-                let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
-                try? await center.add(request) // TODO: This needs testing
-                
-                print("Notification scheduled")
-            } else {
-                print("No notifications")
-            }
+                                
+                let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+                try? await center.add(request)
+//                print("Notification scheduled")
         }
     }
 }

--- a/BoxingScheduler/View Controllers/NowAvailableViewController.swift
+++ b/BoxingScheduler/View Controllers/NowAvailableViewController.swift
@@ -117,29 +117,7 @@ class NowAvailableViewController: UITableViewController {
             }
         }
     }
-    /*
-    func populateNowAvailableFromNotification(_ newAvailableClasses: [MbaClass]) {
-        print("Got to populateNoteAvailableClassesFromNotification")
-        if let existingAvailableClasses = self.availableClasses {
-            self.availableClasses! += newAvailableClasses.filter() { !availableClasses!.contains($0) }
-        } else {
-            self.availableClasses = newAvailableClasses
-        }
-        
-        DispatchQueue.main.async {
-            self.tableView.reloadData()
-        }
-    }
-    
-    func registerForNotifications() {
-        NotificationCenter.default.addObserver(forName: .newScheduleData, object: nil, queue: nil) { (notification) in
-            if let userInfo = notification.userInfo, let availableClasses = userInfo["availableClasses"] as? [MbaClass] {
-                self.populateNowAvailableFromNotification(availableClasses)
-            }
-        }
-    }
-    */
-    
+
     func constrainButton() {
         NSLayoutConstraint.activate([
             scheduleNowButton.heightAnchor.constraint(equalToConstant: 50),

--- a/BoxingScheduler/View Controllers/NowAvailableViewController.swift
+++ b/BoxingScheduler/View Controllers/NowAvailableViewController.swift
@@ -107,7 +107,7 @@ class NowAvailableViewController: UITableViewController {
         let watchedClasses = WatchedClasses()
         Task {
             let allClassList = await watchedClasses.getAllClasses()
-            let nowAvailableClasses = watchedClasses.getNowAvailableClasses(from: allClassList)
+            let nowAvailableClasses = watchedClasses.filterForNowAvailableClasses(from: allClassList)
             self.availableClasses = nowAvailableClasses.sorted()
             self.classesByDate = watchedClasses.createClassDatesFromClasses(self.availableClasses)
 

--- a/BoxingScheduler/View Controllers/ScheduleViewController.swift
+++ b/BoxingScheduler/View Controllers/ScheduleViewController.swift
@@ -41,7 +41,7 @@ class ScheduleViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if let currentlySelected = DataStorage().retrieve() {
+        if let currentlySelected = DataStorage().retrieveWatched() {
             selectedClasses = currentlySelected
             tableView.reloadData()
         } else {

--- a/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
+++ b/BoxingScheduler/View Controllers/WatchedClassesViewController.swift
@@ -37,7 +37,7 @@ class WatchedClassesViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.selectedClasses = DataStorage().retrieve()?.sorted()
+        self.selectedClasses = DataStorage().retrieveWatched()?.sorted()
         
         populateSelectedClasses() {
             DispatchQueue.main.async {


### PR DESCRIPTION
This update fixes/extends the app's ability to use **remote push notifications** to trigger a network check for newly available classes, which are then compared to the previously known available classes (the list of available classes is now persisted to DataStorage any time it is updated). If new classes are actually available, this will trigger a **local notification** alerting the user about the new class.

One issue that contributed to the remote push notification trigger not working before this was that the environment variables for the FCM token (FIREBASE_CLOUD_MANAGER_TOKEN) and server key (FIREBASE_CLOUD_MANAGER_SERVER_KEY) had become out of sync at some point. That was probably due to wiping my device and restoring it from backup, since at least the token is device-specific. Updating those environment variables is not reflected in this PR's changes because they are stored in Firebase's GUI **Secret Manager**. 

An additional, unrelated, issue that this resolves is that didReceiveRemoteNotification MUST call its completion handler and this was not happening. If the completion handler is not called within the 30s of time allotted for this method to process a task, it may use more processing power. The system will track this and possibly begin to suppress the app from waking up to do this processing in the future.